### PR TITLE
fix: 修复空文件下载时 FileAlreadyExistsException 和 WebdavProtocol 调试代码遗留问题

### DIFF
--- a/src/main/java/com/github/balloonupdate/mcpatch/client/Work.java
+++ b/src/main/java/com/github/balloonupdate/mcpatch/client/Work.java
@@ -436,6 +436,10 @@ public class Work {
 
                     // 空文件不需要下载
                     if (f.length == 0) {
+                        // 如果临时文件已存在（上次更新中断），先删除再创建
+                        if (Files.exists(f.tempPath)) {
+                            Files.delete(f.tempPath);
+                        }
                         Files.createFile(f.tempPath);
                         continue;
                     }

--- a/src/main/java/com/github/balloonupdate/mcpatch/client/network/impl/WebdavProtocol.java
+++ b/src/main/java/com/github/balloonupdate/mcpatch/client/network/impl/WebdavProtocol.java
@@ -134,11 +134,6 @@ public class WebdavProtocol implements UpdatingServer {
         try (ContentLengthInputStream input = response.stream) {
             long contentLength = input.getLength();
 
-            if (desc.length() > -999)
-//                throw new IOException("hahahaha");
-            throw new McpatchBusinessException("bbbbbbbbbb");
-//                throw new McpatchBusinessException("qqqqqqqqqqq", new IOException("hahahaha"));
-
             try (OutputStream output = Files.newOutputStream(writeTo)) {
                 byte[] buf = new byte[BytesUtils.chooseBufferSize(contentLength)];
 


### PR DESCRIPTION
## 问题概述

本次 PR 修复了两个关键 Bug：

---

### 问题 1: FileAlreadyExistsException 导致程序崩溃

**文件位置**: `Work.java:438-444`

**问题描述**: 
当下载空文件时，如果临时文件已存在（上次更新中断残留），`Files.createFile()` 会抛出 `FileAlreadyExistsException`，导致整个更新过程崩溃。

**错误日志**:
```
Mcpatch[ 04-04 12:46:21.122 ERROR ] Crash 好像出现了错误
Mcpatch[ 04-04 12:46:21.122 ERROR ] Crash FileAlreadyExistsException: ...\.mcpatch-temp\config\xaeropatreon.txt.temp
```

**修复方案**:
创建空文件前，先检查临时文件是否存在，如果存在则先删除再创建。

```diff
  if (f.length == 0) {
+     // 如果临时文件已存在（上次更新中断），先删除再创建
+     if (Files.exists(f.tempPath)) {
+         Files.delete(f.tempPath);
+     }
      Files.createFile(f.tempPath);
      continue;
  }
```

---

### 问题 2: WebdavProtocol 调试代码遗留导致协议无法使用

**文件位置**: `WebdavProtocol.java:137-141`

**问题描述**: 
代码中遗留了调试代码，条件 `desc.length() > -999` 永远为 true，导致 Webdav 协议下载文件时必定抛出异常，**Webdav 协议完全无法使用**。

**原始代码**:
```java
if (desc.length() > -999)
    throw new McpatchBusinessException("bbbbbbbbbb");
```

**修复方案**:
删除遗留的调试代码。

---

## 测试

- [x] 项目可正常编译 (`./gradlew shadowJar`)
- [x] 修复后逻辑正确
- [x] 不影响其他功能

## 修改文件

| 文件 | 修改类型 |
|------|----------|
| `Work.java` | Bug 修复 |
| `WebdavProtocol.java` | 删除调试代码 |