### PR TITLE
fix: 修复空文件下载时 FileAlreadyExistsException 和 WebdavProtocol 调试代码遗留问题 + 添加 GitHub Actions 工作流

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Auto Build
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build with Gradle
+        run: ./gradlew shadowJar --no-daemon
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Mcpatch-build-${{ github.sha }}
+          path: build/libs/*.jar
+          retention-days: 7

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,105 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.0.0)'
+        required: true
+        type: string
+      prerelease:
+        description: 'Is this a pre-release?'
+        required: false
+        default: false
+        type: boolean
+      draft:
+        description: 'Create as draft?'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build with Gradle
+        run: ./gradlew shadowJar --no-daemon
+
+      - name: Get commit SHA
+        id: commit
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Create Git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          # 获取上一个 tag
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
+          
+          if [ -z "$PREV_TAG" ]; then
+            # 如果没有上一个 tag，获取所有提交
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges -20)
+          else
+            # 获取两个 tag 之间的提交
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges $PREV_TAG..HEAD)
+          fi
+          
+          # 保存到文件（多行内容）
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ inputs.version }}
+          name: Mcpatch v${{ inputs.version }}
+          body: |
+            ## Mcpatch v${{ inputs.version }}
+            
+            **构建信息：**
+            - 版本: ${{ inputs.version }}
+            - 提交: ${{ steps.commit.outputs.sha }}
+            - 构建时间: ${{ github.event.head_commit.timestamp }}
+            
+            **更新内容：**
+            ${{ steps.changelog.outputs.changelog }}
+            
+            ---
+            
+            **使用方法：**
+            下载 `Mcpatch-${{ inputs.version }}.jar` 文件，按照项目说明进行部署。
+          files: build/libs/*.jar
+          draft: ${{ inputs.draft }}
+          prerelease: ${{ inputs.prerelease }}
+          generate_release_notes: false
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Mcpatch-v${{ inputs.version }}
+          path: build/libs/*.jar
+          retention-days: 30


### PR DESCRIPTION
## 问题概述

本次 PR 修复了两个关键 Bug，并新增了两个 GitHub Actions 工作流：

---

### 问题 1: FileAlreadyExistsException 导致程序崩溃

**文件位置**: `Work.java:438-444`

**问题描述**: 
当下载空文件时，如果临时文件已存在（上次更新中断残留），`Files.createFile()` 会抛出 `FileAlreadyExistsException`，导致整个更新过程崩溃。

**错误日志**:
```
Mcpatch[ 04-04 12:46:21.122 ERROR ] Crash 好像出现了错误
Mcpatch[ 04-04 12:46:21.122 ERROR ] Crash FileAlreadyExistsException: ...\.mcpatch-temp\config\xaeropatreon.txt.temp
```

**修复方案**:
创建空文件前，先检查临时文件是否存在，如果存在则先删除再创建。

---

### 问题 2: WebdavProtocol 调试代码遗留导致协议无法使用

**文件位置**: `WebdavProtocol.java:137-141`

**问题描述**: 
代码中遗留了调试代码，条件 `desc.length() > -999` 永远为 true，导致 Webdav 协议下载文件时必定抛出异常，**Webdav 协议完全无法使用**。

**修复方案**:
删除遗留的调试代码。

---

### 新增: GitHub Actions 工作流

**1. build.yml - 自动构建**
- 推送到 main/master 分支时自动触发
- PR 到 main/master 分支时自动触发
- 构建完成后上传 artifact 保留 7 天

**2. manual-release.yml - 手动发布**
- 手动触发，可输入版本号
- 可选择是否为预发布版本或草稿
- 自动创建 Git tag 并发布 Release
- 自动生成 changelog

---

## 测试

- [x] 项目可正常编译 (`./gradlew shadowJar`)
- [x] 修复后逻辑正确
- [x] 不影响其他功能

## 修改文件

| 文件 | 修改类型 |
|------|----------|
| `Work.java` | Bug 修复 |
| `WebdavProtocol.java` | 删除调试代码 |
| `.github/workflows/build.yml` | 新增文件 |
| `.github/workflows/manual-release.yml` | 新增文件 |