### PR TITLE
fix: 修复 Files.move 时的 FileAlreadyExistsException

### DIFF
--- a/src/main/java/com/github/balloonupdate/mcpatch/client/Work.java
+++ b/src/main/java/com/github/balloonupdate/mcpatch/client/Work.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -532,7 +533,7 @@ public class Work {
                 Log.debug("    To   " + to);
 
                 if (Files.exists(from)) {
-                    Files.move(from, to);
+                    Files.move(from, to, StandardCopyOption.REPLACE_EXISTING);
                 }
             }
 
@@ -585,7 +586,7 @@ public class Work {
                     throw new McpatchBusinessException("移动临时文件时，要被移动的源文件不存在: " + from);
                 }
 
-                Files.move(from, to);
+                Files.move(from, to, StandardCopyOption.REPLACE_EXISTING);
             }
 
             // 6.清理临时文件夹


### PR DESCRIPTION
## 问题描述

在 Android 虚拟化环境（如 Fold Craft Launcher）中运行时，更新过程中会出现 `FileAlreadyExistsException` 错误：

```
Mcpatch[ ERROR ] Crash  FileAlreadyExistsException: .../options.txt
```

## 原因分析

Android 虚拟化环境中的文件系统操作可能存在延迟。虽然代码在移动文件前会先删除目标文件，但由于文件系统缓存等原因，`Files.move()` 执行时目标文件可能仍然存在，导致异常。

## 修复内容

为两处 `Files.move()` 调用添加 `StandardCopyOption.REPLACE_EXISTING` 选项：

- 第536行：处理文件移动操作
- 第589行：处理临时文件移动操作

这样即使目标文件因文件系统延迟未能立即删除，移动操作也能正确覆盖目标文件。

## 测试

此修复解决了用户在 Fold Craft Launcher（Android）环境下更新时遇到的崩溃问题。